### PR TITLE
Add autoupdate with latest version of zephyrprojectrtos/ci

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -2,10 +2,16 @@ name: Publish to GHCR
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
-    publish:
-        uses: catie-aq/generic_workflows/.github/workflows/docker-ghcr.yml@main
-        secrets:
-            PAT: ${{ secrets.GITHUB_TOKEN }}
+  publish:
+    uses: catie-aq/generic_workflows/.github/workflows/docker-ghcr.yml@main
+    secrets:
+      PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-zephyr-tag.yml
+++ b/.github/workflows/update-zephyr-tag.yml
@@ -1,0 +1,59 @@
+name: Update Dockerfile and Tag
+
+on:
+  push:
+
+jobs:
+  update-dockerfile:
+    runs-on: sonu-github-arc
+    container:
+      image: ubuntu:latest
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y curl jq git
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: workdir
+
+      - name: Get latest tag from zephyrproject-rtos/docker-image
+        id: get_latest_zephyr_tag
+        run: |
+          latest_zephyr_tag=$(curl -s https://api.github.com/repos/zephyrproject-rtos/docker-image/tags | jq -r '.[0].name')
+          echo "::set-output name=zephyr_tag::$latest_zephyr_tag"
+
+      - name: Get Previous tag
+        id: previous_tag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          workingDirectory: workdir
+
+      - name: Update Dockerfile, commit, push changes, and create new tag if necessary
+        if: steps.get_latest_zephyr_tag.outputs.zephyr_tag != steps.previous_tag.outputs.tag
+        run: |
+          cd workdir
+          latest_zephyr_tag=${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}
+          sed -i "s|^FROM zephyrprojectrtos/ci:.*|FROM zephyrprojectrtos/ci:${latest_zephyr_tag}|" Dockerfile
+
+      # TODO: Use a GitHub App token to open a pull request, need admin access to the repository
+      # - uses: tibdex/github-app-token@v1
+      #   id: generate-token
+      #   with:
+      #     app_id: ${{ secrets.APP_ID }}
+      #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          path: workdir
+          branch: update-dockerfile-${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}
+          title: "Update Dockerfile to use zephyrprojectrtos/ci:${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}"
+          commit-message: "Update Dockerfile to use zephyrprojectrtos/ci:${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}"
+          labels: dependencies
+          delete-branch: true
+          # token: ${{ secrets.GITHUB_TOKEN }}
+          reviewers: clementlgl

--- a/.github/workflows/update-zephyr-tag.yml
+++ b/.github/workflows/update-zephyr-tag.yml
@@ -39,12 +39,11 @@ jobs:
           latest_zephyr_tag=${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}
           sed -i "s|^FROM zephyrprojectrtos/ci:.*|FROM zephyrprojectrtos/ci:${latest_zephyr_tag}|" Dockerfile
 
-      # TODO: Use a GitHub App token to open a pull request, need admin access to the repository
-      # - uses: tibdex/github-app-token@v1
-      #   id: generate-token
-      #   with:
-      #     app_id: ${{ secrets.APP_ID }}
-      #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Open Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -55,5 +54,5 @@ jobs:
           commit-message: "Update Dockerfile to use zephyrprojectrtos/ci:${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}"
           labels: dependencies
           delete-branch: true
-          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           reviewers: clementlgl


### PR DESCRIPTION
Improvements to publish workflow:

* [`.github/workflows/publish-ghcr.yml`](diffhunk://#diff-dfd79d1c83d7729b30f5a4f2d60cffc46b267e95c7dff8fa078c86c2e7db8cf3R5-R13): Added branch-specific triggers for `main`, pull request events, and concurrency control to ensure only one workflow runs at a time per branch.

New workflow for updating Dockerfiles:

* [`.github/workflows/update-zephyr-tag.yml`](diffhunk://#diff-bc6bdd124d154c0632f49302621361c32eebf3497963326a45fa2987ee06a8ceR1-R59): Created a new workflow to update Dockerfiles with the latest tags from the Zephyr project, including steps for checking out the repository, getting the latest and previous tags, updating the Dockerfile, and opening a pull request if necessary.