### PR TITLE
Add SEGGER J-Link installation to workspace image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM zephyrprojectrtos/ci:v0.26.16 as workspace 
 
+RUN wget --post-data "accept_license_agreement=accepted" https://www.segger.com/downloads/jlink/JLink_Linux_V796c_x86_64.tgz \
+    && mkdir -p /opt/SEGGER/JLink \
+    && tar -xvf JLink_Linux_V796c_x86_64.tgz -C /opt/SEGGER/JLink \
+    && ln -s /opt/SEGGER/JLink/JLink_Linux_V796c_x86_64/JLinkExe /usr/bin/JLinkExe \
+    && mkdir -p /etc/udev/rules.d \
+    && cp /opt/SEGGER/JLink/JLink_Linux_V796c_x86_64/99-jlink.rules /etc/udev/rules.d/ \
+    && rm JLink_Linux_V796c_x86_64.tgz
+
 RUN west init -m https://github.com/catie-aq/6tron_zephyr-workspace 6tron-workspace
 WORKDIR /6tron-workspace
 RUN west update


### PR DESCRIPTION
This pull request add support for SEGGER J-Link tools to workspace image.

Changes to `Dockerfile`:

* Added commands to download the J-Link software from SEGGER's website, extract it, and create necessary symbolic links and udev rules.