### PR TITLE
Update GitHub Actions workflow for version tags

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish-ghcr.yml` file. The change adds tags under the `push` event to trigger the workflow on version tags matching the pattern `v*.*.*`.