### PR TITLE
Remove ref in publish-ghcr.yml concurrency

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
 
 jobs:
   publish:


### PR DESCRIPTION
* [`.github/workflows/publish-ghcr.yml`](diffhunk://#diff-dfd79d1c83d7729b30f5a4f2d60cffc46b267e95c7dff8fa078c86c2e7db8cf3L12-R12): Modified `concurrency` group to use only `${{ github.workflow }}` instead of `${{ github.workflow }}-${{ github.ref }}`.