### PR TITLE
Fix Dockerfile to update Zephyr image tag format

### DIFF
--- a/.github/workflows/update-zephyr-tag.yml
+++ b/.github/workflows/update-zephyr-tag.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cd workdir
           latest_zephyr_tag=${{ steps.get_latest_zephyr_tag.outputs.zephyr_tag }}
-          sed -i "s|^FROM zephyrprojectrtos/ci:.*|FROM zephyrprojectrtos/ci:${latest_zephyr_tag}|" Dockerfile
+          sed -i "s|zephyrprojectrtos/ci:v[0-9]*\.[0-9]*\.[0-9]*|zephyrprojectrtos/ci:${latest_zephyr_tag}|" Dockerfile
 
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
Workflow improvements:

* [`.github/workflows/update-zephyr-tag.yml`](diffhunk://#diff-bc6bdd124d154c0632f49302621361c32eebf3497963326a45fa2987ee06a8ceL41-R41): Modified the `sed` command to use a more precise regular expression for matching the Zephyr project version, ensuring accurate updates to the Dockerfile.