### PR TITLE
Split GHCR publishing workflow to trigger the Workspace image build separately

### DIFF
--- a/.github/workflows/publish-ghcr-ci-dev.yml
+++ b/.github/workflows/publish-ghcr-ci-dev.yml
@@ -1,4 +1,4 @@
-name: Publish to GHCR
+name: Publish to GHCR CI and Dev images
 
 on:
   push:
@@ -22,9 +22,3 @@ jobs:
       PAT: ${{ secrets.GITHUB_TOKEN }}
     with:
       target: dev
-  publish-workspace:
-    uses: catie-aq/generic_workflows/.github/workflows/docker-ghcr.yml@main
-    secrets:
-      PAT: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      target: workspace

--- a/.github/workflows/publish-ghcr-workspace.yml
+++ b/.github/workflows/publish-ghcr-workspace.yml
@@ -1,0 +1,15 @@
+name: Publish to GHCR Workspace image
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  publish-workspace:
+    uses: catie-aq/generic_workflows/.github/workflows/docker-ghcr.yml@main
+    secrets:
+      PAT: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      target: workspace


### PR DESCRIPTION
This pull request introduces changes to GitHub Actions workflows to enhance the publishing process for Docker images. 
It allows you to separate the triggering of images ci / dev and workspace.

### Workflow updates:

* [`.github/workflows/publish-ghcr-ci-dev.yml`](diffhunk://#diff-be0e4c70bc5cd4e19977b8cd57a0f09f2f755540e0e7a3395a52279a329d25ebL1-R1): Renamed from `.github/workflows/publish-ghcr.yml` and updated the workflow name to "Publish to GHCR CI and Dev images" for better clarity.
* [`.github/workflows/publish-ghcr-workspace.yml`](diffhunk://#diff-879bb7b49a1c40463dce21445e7714ceb667c76065a2379ffea8d2951b8c5c23R1-R15): Added a new workflow named "Publish to GHCR Workspace image," which uses a reusable workflow to publish a workspace Docker image with a `workflow_dispatch` trigger and concurrency control.